### PR TITLE
[Feat] OAuth 로그인 회원 ID 추출 기능 구현 완료 (#29)

### DIFF
--- a/src/main/java/urecagroup1backend/member/controller/MemberController.java
+++ b/src/main/java/urecagroup1backend/member/controller/MemberController.java
@@ -3,12 +3,11 @@ package urecagroup1backend.member.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import urecagroup1backend.config.ApiResponse;
 import urecagroup1backend.member.controller.docs.MemberControllerDocs;
+import urecagroup1backend.member.domain.CustomUserDetails;
 import urecagroup1backend.member.domain.Member;
 import urecagroup1backend.member.domain.SocialType;
 import urecagroup1backend.member.dto.MemberCreateDto;
@@ -81,7 +80,7 @@ public class MemberController implements MemberControllerDocs {
         }
 
         // 회원 가입 되어 있는 회원이면 토큰 발급
-        String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getName());
+        String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getId(), originalMember.getName());
 
         Map<String, Object> loginInfo = new HashMap<>();
         loginInfo.put("id", originalMember.getId());
@@ -106,13 +105,24 @@ public class MemberController implements MemberControllerDocs {
         }
 
         // 회원 가입 되어 있는 회원이면 토큰 발급
-        String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getName());
+        String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getId(), originalMember.getName());
 
         Map<String, Object> loginInfo = new HashMap<>();
         loginInfo.put("id", originalMember.getId());
         loginInfo.put("token", jwtToken);
 
         return new ApiResponse<>(HttpStatus.OK, "카카오 로그인에 성공했습니다.", loginInfo);
+    }
+
+    // 내 로그인 정보 가져오기
+    @GetMapping("/me")
+    public ApiResponse<?> me(@AuthenticationPrincipal CustomUserDetails user) {
+        Map<String, Object> loginInfo = new HashMap<>();
+        loginInfo.put("id", user.getId());
+        loginInfo.put("email", user.getEmail());
+        loginInfo.put("name", user.getName());
+
+        return new ApiResponse<>(HttpStatus.OK, "내 로그인 정보", loginInfo);
     }
 
 

--- a/src/main/java/urecagroup1backend/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/urecagroup1backend/member/controller/docs/MemberControllerDocs.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import urecagroup1backend.member.domain.CustomUserDetails;
 import urecagroup1backend.oauth.dto.RedirectDto;
 
 import java.util.Map;
@@ -66,4 +68,34 @@ public interface MemberControllerDocs {
             @Schema(description = "카카오 리디렉션 코드 정보", implementation = RedirectDto.class)
             RedirectDto redirectDto
     );
+
+    @Operation(
+            summary = "내 로그인 정보 조회",
+            description = "현재 로그인한 사용자의 ID, 이메일, 이름 정보를 조회합니다. JWT 토큰을 통해 인증된 사용자만 접근 가능합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "로그인 정보 조회 성공",
+            content = @Content(
+                    examples = @ExampleObject(
+                            value = """
+                                    {
+                                      "status": 200,
+                                      "message": "내 로그인 정보",
+                                      "data": {
+                                        "id": 1,
+                                        "email": "user@example.com",
+                                        "name": "홍길동"
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패: 토큰 없음 혹은 잘못된 토큰"
+    )
+    urecagroup1backend.config.ApiResponse<?> me(@AuthenticationPrincipal CustomUserDetails user);
 }
+

--- a/src/main/java/urecagroup1backend/member/domain/CustomUserDetails.java
+++ b/src/main/java/urecagroup1backend/member/domain/CustomUserDetails.java
@@ -1,0 +1,35 @@
+package urecagroup1backend.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private Long id;
+    private String email;
+    private String name;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/src/main/java/urecagroup1backend/oauth/JwtTokenFilter.java
+++ b/src/main/java/urecagroup1backend/oauth/JwtTokenFilter.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import urecagroup1backend.member.domain.CustomUserDetails;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,10 +49,21 @@ public class JwtTokenFilter extends GenericFilter {
                         .parseClaimsJws(jwtToken)
                         .getBody();
 
+                // 현재 로그인한 유저의 id, 이메일, 이름 추출
+                Long id = claims.get("id", Long.class);
+                String email = claims.getSubject();
+                String name = claims.get("name", String.class);
+
+                // CustomUserDetails 생성
+                CustomUserDetails userDetails = CustomUserDetails.builder()
+                        .id(id)
+                        .email(email)
+                        .name(name)
+                        .build();
+
                 // Authentication 객체 생성
                 List<GrantedAuthority> authorities = new ArrayList<>();
                 authorities.add(new SimpleGrantedAuthority("ROLE_" + claims.get("role")));
-                UserDetails userDetails = new User(claims.getSubject(), "", authorities);
                 Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, jwtToken, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/urecagroup1backend/oauth/JwtTokenProvider.java
+++ b/src/main/java/urecagroup1backend/oauth/JwtTokenProvider.java
@@ -25,9 +25,10 @@ public class JwtTokenProvider {
         this.SECRET_KEY = new SecretKeySpec(Base64.getDecoder().decode(secretKey), SignatureAlgorithm.HS512.getJcaName());
     }
 
-    public String createToken(String email, String name) {
+    public String createToken(String email, Long id, String name) {
         // claims는 jwt 토큰의 playload 부분을 의미
         Claims claims = Jwts.claims().setSubject(email);
+        claims.put("id", id);
         claims.put("name", name);
 
         Date now = new Date();

--- a/src/main/java/urecagroup1backend/oauth/service/GoogleOAuth2LoginSuccess.java
+++ b/src/main/java/urecagroup1backend/oauth/service/GoogleOAuth2LoginSuccess.java
@@ -44,7 +44,7 @@ public class GoogleOAuth2LoginSuccess extends SimpleUrlAuthenticationSuccessHand
         }
 
         // jwt 토큰 생성
-        String jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getName());
+        String jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getId(), member.getName());
 
         // 클라이언트 redirect 방식으로 토큰 전달
         // response.sendRedirect("http://localhost:3000?token=" + jwtToken);

--- a/src/main/java/urecagroup1backend/oauth/service/KakaoOAuth2LoginSuccess.java
+++ b/src/main/java/urecagroup1backend/oauth/service/KakaoOAuth2LoginSuccess.java
@@ -52,7 +52,7 @@ public class KakaoOAuth2LoginSuccess extends SimpleUrlAuthenticationSuccessHandl
         }
 
         // 3. jwt 토큰 생성 및 전달
-        String jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getName());
+        String jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getId(), member.getName());
 
         Cookie jwtCookie = new Cookie("token", jwtToken);
         jwtCookie.setPath("/");


### PR DESCRIPTION
## 제목 : [태그] PR 제목

## 📝작업 내용

현재 로그인한 회원의 id, email, name을 추출하는 기능 제작 완료

<br/>

## 👀변경 사항

각 도메인 Controller 코드에서 파라미터로
- @AuthenticationPrincipal CustomUserDetails user 넣은 후 user.getId(), user.getEmail(), user.getName() 하면 현재 사용자의 id, 이메일, 이름 추출 가능
- 단, 현재 이름은 카카오에서 필수값이 아니라서 null처리 되어 있음

<br/>

## #️⃣관련 이슈

#29 