### PR TITLE
[Fix] oauth 로그인 cookie 부분 배포 환경에 맞게 수정

### DIFF
--- a/src/main/java/urecagroup1backend/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/urecagroup1backend/auth/handler/OAuth2SuccessHandler.java
@@ -70,8 +70,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private Cookie createCookie(String key, String value, int expiration) {
         Cookie cookie = new Cookie(key, value);
         cookie.setPath("/");
-        // cookie.setSecure(true); // https 에서만 전송 (운영환경에서만)
-        // cookie.setHttpOnly(true); // 클라이언트 속 JS 접근 불가 (XSS 방어)
+        cookie.setSecure(true); // https 에서만 전송 (운영환경에서만)
+        cookie.setHttpOnly(true); // 클라이언트 속 JS 접근 불가 (XSS 방어)
         cookie.setMaxAge(expiration); // 만료시간 : Token 유효기간과 동일하게 맞추기
 
         return cookie;

--- a/src/main/java/urecagroup1backend/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/urecagroup1backend/auth/handler/OAuth2SuccessHandler.java
@@ -40,7 +40,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
-
         // accessToken, refreshToken 발급
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);

--- a/src/main/java/urecagroup1backend/member/controller/MemberController.java
+++ b/src/main/java/urecagroup1backend/member/controller/MemberController.java
@@ -63,8 +63,8 @@ public class MemberController implements MemberControllerDocs {
         // 리프레시토큰은 쿠키에 넣어서 보내기
         Cookie refreshCookie = new Cookie("refresh", newToken.getRefreshToken());
         refreshCookie.setPath("/");
-        // refreshCookie.setSecure(true); // https 에서만 전송 (운영환경에서만)
-        // refreshCookie.setHttpOnly(true); // 클라이언트 속 JS 접근 불가 (XSS 방어)
+        refreshCookie.setSecure(true); // https 에서만 전송 (운영환경에서만)
+        refreshCookie.setHttpOnly(true); // 클라이언트 속 JS 접근 불가 (XSS 방어)
         refreshCookie.setMaxAge(jwtTokenProvider.getREFRESH_EXPIRATION()); // 만료시간 : refreshToken 유효기간과 동일하게 맞추기
         response.addCookie(refreshCookie);
 

--- a/src/main/java/urecagroup1backend/member/controller/MemberController.java
+++ b/src/main/java/urecagroup1backend/member/controller/MemberController.java
@@ -60,7 +60,7 @@ public class MemberController implements MemberControllerDocs {
         // 액세스 토큰은 헤더에
         response.addHeader("Authorization", "Bearer " + newToken.getAccessToken());
 
-        // 리프레시토큰은 쿠키에 넣어서 보내기
+        // 리프레시 토큰은 쿠키에 넣어서 보내기
         Cookie refreshCookie = new Cookie("refresh", newToken.getRefreshToken());
         refreshCookie.setPath("/");
         refreshCookie.setSecure(true); // https 에서만 전송 (운영환경에서만)


### PR DESCRIPTION
## 📝작업 내용

oauth 로그인 cookie 부분 배포 환경에 맞게 수정

<br/>

## 👀변경 사항

로그인 성공 / 토큰 재발급시

addCookie() 할 때
setSecure(true)
setHttpOnly(true)

수정 완료

<br/>

