### PR TITLE
[Fix] Cookie -> ResponseCookie로 변경 후 sameSite(), domain() 추가

### DIFF
--- a/src/main/java/urecagroup1backend/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/urecagroup1backend/auth/handler/OAuth2SuccessHandler.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -56,23 +58,22 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         // 최초 로그인 시 (액세스 토큰, 리프레시 토큰) 모두 쿠키에 담아서 프론트에 전달 후,
         // 프론트에서 쿠키에서 액세스 토큰 추출해 localStorage에 저장 후 쿠키에서 삭제하는 방법 선택
 
-        // 쿠키에 accessToken 전달
-        response.addCookie(createCookie("access", accessToken, jwtTokenProvider.getACCESS_EXPIRATION()));
+        // 액세스 토큰은 헤더에
+        response.addHeader("Authorization", "Bearer " + accessToken);
 
-        // 쿠키에 refreshToken 전달
-        response.addCookie(createCookie("refresh", refreshToken, jwtTokenProvider.getREFRESH_EXPIRATION()));
+        // 리프레시 토큰은 쿠키에 넣어서 보내기
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh", refreshToken)
+                .path("/")
+                .secure(true) // https 에서만 전송 (운영환경에서만)
+                .httpOnly(true) // 클라이언트 속 JS 접근 불가 (XSS 방어)
+                .sameSite("None") // 백엔드 - 프론트엔드 URL이 달라서 추가 필요함
+                .domain(".urecastudycafe.store/") // (하드코딩 수정?) 백엔드 - 프론트엔드 모두 사용가능한 도메인 설정 필요
+                .maxAge(jwtTokenProvider.getREFRESH_EXPIRATION()) // 만료시간 : refreshToken 유효기간과 동일하게 맞추기
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         // 리다이렉트
         response.sendRedirect(redirectUrl);
-    }
-
-    private Cookie createCookie(String key, String value, int expiration) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setPath("/");
-        cookie.setSecure(true); // https 에서만 전송 (운영환경에서만)
-        cookie.setHttpOnly(true); // 클라이언트 속 JS 접근 불가 (XSS 방어)
-        cookie.setMaxAge(expiration); // 만료시간 : Token 유효기간과 동일하게 맞추기
-
-        return cookie;
     }
 }

--- a/src/main/java/urecagroup1backend/member/controller/MemberController.java
+++ b/src/main/java/urecagroup1backend/member/controller/MemberController.java
@@ -5,7 +5,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import urecagroup1backend.config.ApiResponse;
@@ -61,12 +63,16 @@ public class MemberController implements MemberControllerDocs {
         response.addHeader("Authorization", "Bearer " + newToken.getAccessToken());
 
         // 리프레시 토큰은 쿠키에 넣어서 보내기
-        Cookie refreshCookie = new Cookie("refresh", newToken.getRefreshToken());
-        refreshCookie.setPath("/");
-        refreshCookie.setSecure(true); // https 에서만 전송 (운영환경에서만)
-        refreshCookie.setHttpOnly(true); // 클라이언트 속 JS 접근 불가 (XSS 방어)
-        refreshCookie.setMaxAge(jwtTokenProvider.getREFRESH_EXPIRATION()); // 만료시간 : refreshToken 유효기간과 동일하게 맞추기
-        response.addCookie(refreshCookie);
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh", newToken.getRefreshToken())
+            .path("/")
+            .secure(true) // https 에서만 전송 (운영환경에서만)
+            .httpOnly(true) // 클라이언트 속 JS 접근 불가 (XSS 방어)
+            .sameSite("None") // 백엔드 - 프론트엔드 URL이 달라서 추가 필요함
+            .domain(".urecastudycafe.store/") // (하드코딩 수정?) 백엔드 - 프론트엔드 모두 사용가능한 도메인 설정 필요
+            .maxAge(jwtTokenProvider.getREFRESH_EXPIRATION()) // 만료시간 : refreshToken 유효기간과 동일하게 맞추기
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         return new ApiResponse<>(HttpStatus.OK, "AccessToken & RefreshToken갱신 완료", null);
     }


### PR DESCRIPTION
## 📝작업 내용

배포 환경에서 로그인 안되는 문제 해결하기 위해
SuccessHandler, MemberController.reissueToken() 코드 수정

## 👀변경 사항

AccessToken
- 로그인 성공 / 토큰 재발급 시 모두 Header에 포함시켜 보내는 것으로 변경

<br/>

RefreshToken
- Cookie -> ResponseCookie로 변경
  - .sameSite("None")
  - .domain(".urecastudycafe.store")


<br/>

## #️⃣관련 이슈

Closes #83 